### PR TITLE
Allow building libjdk.a for linux-aarch64

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -51,10 +51,10 @@ jobs:
       matrix:
         target-cpu:
           - aarch64
-          - arm
-          - s390x
-          - ppc64le
-          - riscv64
+#          - arm
+#          - s390x
+#          - ppc64le
+#          - riscv64
         include:
           - target-cpu: aarch64
             gnu-arch: aarch64
@@ -62,31 +62,31 @@ jobs:
             debian-repository: https://httpredir.debian.org/debian/
             debian-version: bullseye
             tolerate-sysroot-errors: false
-          - target-cpu: arm
-            gnu-arch: arm
-            debian-arch: armhf
-            debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
-            tolerate-sysroot-errors: false
-            gnu-abi: eabihf
-          - target-cpu: s390x
-            gnu-arch: s390x
-            debian-arch: s390x
-            debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
-            tolerate-sysroot-errors: false
-          - target-cpu: ppc64le
-            gnu-arch: powerpc64le
-            debian-arch: ppc64el
-            debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
-            tolerate-sysroot-errors: false
-          - target-cpu: riscv64
-            gnu-arch: riscv64
-            debian-arch: riscv64
-            debian-repository: https://httpredir.debian.org/debian/
-            debian-version: sid
-            tolerate-sysroot-errors: true
+#          - target-cpu: arm
+#            gnu-arch: arm
+#            debian-arch: armhf
+#            debian-repository: https://httpredir.debian.org/debian/
+#            debian-version: bullseye
+#            tolerate-sysroot-errors: false
+#            gnu-abi: eabihf
+#          - target-cpu: s390x
+#            gnu-arch: s390x
+#            debian-arch: s390x
+#            debian-repository: https://httpredir.debian.org/debian/
+#            debian-version: bullseye
+#            tolerate-sysroot-errors: false
+#          - target-cpu: ppc64le
+#            gnu-arch: powerpc64le
+#            debian-arch: ppc64el
+#            debian-repository: https://httpredir.debian.org/debian/
+#            debian-version: bullseye
+#            tolerate-sysroot-errors: false
+#          - target-cpu: riscv64
+#            gnu-arch: riscv64
+#            debian-arch: riscv64
+#            debian-repository: https://httpredir.debian.org/debian/
+#            debian-version: sid
+#            tolerate-sysroot-errors: true
 
     steps:
       - name: 'Checkout the JDK source'

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -37,6 +37,10 @@ on:
       extra-conf-options:
         required: false
         type: string
+      debug-levels:
+        required: false
+        type: string
+        default: '[ "release" ]'
       configure-arguments:
         required: false
         type: string

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -28,6 +28,9 @@ name: 'Build (cross-compile)'
 on:
   workflow_call:
     inputs:
+      platform:
+        required: true
+        type: string
       gcc-major-version:
         required: true
         type: string
@@ -40,6 +43,10 @@ on:
       make-arguments:
         required: false
         type: string
+      make-target:
+        required: false
+        type: string
+        default: 'static-libs'
 
 jobs:
   build-cross-compile:

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -201,6 +201,6 @@ jobs:
       - name: 'Upload bundles'
         uses: ./.github/actions/upload-bundles
         with:
-          platform: ${{ inputs.platform }}
+          platform: linux-${{ matrix.target-cpu }}
           debug-suffix: '${{ matrix.suffix }}'
           make-target: 'static-libs'

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -186,3 +186,10 @@ jobs:
           make-target: 'hotspot ${{ inputs.make-arguments }}'
           platform: linux-${{ matrix.target-cpu }}
         if: steps.create-sysroot.outcome == 'success' || steps.get-cached-sysroot.outputs.cache-hit == 'true'
+
+      - name: 'Upload bundles'
+        uses: ./.github/actions/upload-bundles
+        with:
+          platform: ${{ inputs.platform }}
+          debug-suffix: '${{ matrix.suffix }}'
+          make-target: 'static-libs'

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -202,5 +202,4 @@ jobs:
         uses: ./.github/actions/upload-bundles
         with:
           platform: linux-${{ matrix.target-cpu }}
-          debug-suffix: '${{ matrix.suffix }}'
           make-target: 'static-libs'

--- a/.github/workflows/static-build.yml
+++ b/.github/workflows/static-build.yml
@@ -197,7 +197,7 @@ jobs:
       debug-levels: '[ "release" ]'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.linux-aarch64 == 'true'  
+    if: needs.select.outputs.linux-cross-compile == 'true'  
 
   build-macos-x64:
     name: macos-x64

--- a/.github/workflows/static-build.yml
+++ b/.github/workflows/static-build.yml
@@ -186,12 +186,12 @@ jobs:
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x64 == 'true'
 
-  build-linux-aarch64:
-    name: linux-aarch64
+  build-linux-cross-compile:
+    name: linux-cross-compile
     needs: select
     uses: ./.github/workflows/build-cross-compile.yml
     with:
-      platform: linux-x64
+      platform: linux-cross-compile
       make-target: 'static-libs'
       gcc-major-version: '10'
       debug-levels: '[ "release" ]'

--- a/.github/workflows/static-build.yml
+++ b/.github/workflows/static-build.yml
@@ -31,7 +31,7 @@ on:
       platforms:
         description: 'Platform(s) to execute on (comma separated, e.g. "android-linux-aarch64, ios-macos-aarch64, linux-x64, macos, aarch64")'
         required: true
-        default: 'android-linux-aarch64, ios-macos-aarch64, linux-x64, macos-x64, macos-aarch64, windows-x64, windows-aarch64'
+        default: 'android-linux-aarch64, ios-macos-aarch64, linux-x64, linux-cross-compile, macos-x64, macos-aarch64, windows-x64, windows-aarch64'
       configure-arguments:
         description: 'Additional configure arguments'
         required: false

--- a/.github/workflows/static-build.yml
+++ b/.github/workflows/static-build.yml
@@ -265,6 +265,7 @@ jobs:
       - build-android-linux-aarch64
       - build-ios-macos-aarch64
       - build-linux-x64
+      - build-linux-cross-compile
       - build-macos-x64
       - build-macos-aarch64
       - build-windows-x64

--- a/.github/workflows/static-build.yml
+++ b/.github/workflows/static-build.yml
@@ -186,6 +186,19 @@ jobs:
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x64 == 'true'
 
+  build-linux-aarch64:
+    name: linux-aarch64
+    needs: select
+    uses: ./.github/workflows/build-cross-compile.yml
+    with:
+      platform: linux-x64
+      make-target: 'static-libs'
+      gcc-major-version: '10'
+      debug-levels: '[ "release" ]'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
+    if: needs.select.outputs.linux-aarch64 == 'true'  
+
   build-macos-x64:
     name: macos-x64
     needs: select

--- a/.github/workflows/static-release.yml
+++ b/.github/workflows/static-release.yml
@@ -59,6 +59,15 @@ jobs:
       gcc-major-version: '10'
       debug-levels: '[ "release" ]'
 
+  build-linux-cross-compile:
+    name: linux-cross-compile
+    uses: ./.github/workflows/build-cross-compile.yml
+    with:
+      platform: linux-cross-compile
+      make-target: 'static-libs'
+      gcc-major-version: '10'
+      debug-levels: '[ "release" ]'
+
   build-macos-x64:
     name: macos-x64
     uses: ./.github/workflows/build-macos.yml
@@ -103,7 +112,7 @@ jobs:
   release:
     needs: [
         build-android-linux-aarch64, build-ios-macos-aarch64,
-        build-linux-x64,
+        build-linux-x64, build-linux-cross-compile,
         build-macos-x64, build-macos-aarch64,
         build-windows-x64, build-windows-aarch64
     ]
@@ -126,6 +135,12 @@ jobs:
         with:
           name: linux-x64
           path: ./dist/linux-x64
+
+      - name: Download Linux AArch64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-aarch64
+          path: ./dist/linux-aarch64
 
       - name: Download macOS x64 artifact
         uses: actions/download-artifact@v4
@@ -162,6 +177,7 @@ jobs:
           zip -r android-linux-aarch64.zip android-linux-aarch64
           zip -r ios-macos-aarch64.zip ios-macos-aarch64
           zip -r linux-x64.zip linux-x64
+          zip -r linux-aarch64.zip linux-aarch64
           zip -r macos-x64.zip macos-x64
           zip -r macos-aarch64.zip macos-aarch64
           zip -r windows-x64.zip windows-x64


### PR DESCRIPTION
Use `linux-cross-compile` job, but only for `linux-aarch64`, not other targets (arm, s390x, ppc64le, riscv64)